### PR TITLE
Add possibility to set new primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download the binary from [releases](https://github.com/chmln/enact/releases) or 
 Test it out then place this in your `.xinitrc`.
 
 ```sh
-# Set up second monitor above laptop 
+# Set up second monitor above laptop
 enact --pos top
 ```
 
@@ -26,6 +26,12 @@ Or to do the same, but also watch for changes and allow hotplugging
 
 ```sh
 enact --pos top --watch &
+```
+
+You can also select which monitor will be the new primary one
+
+```sh
+enact --pos top --new_primary 1
 ```
 
 ## Comparison With Similar Tools
@@ -40,4 +46,4 @@ Drawbacks:
 
 ## Icon Attribution
 
-[“Monitor”](https://www.iconfinder.com/icons/4064140/computer_hardware_monitor_screen_technology_icon) by [icon lauk](https://www.iconfinder.com/andhikairfani), licensed under CC BY 3.0. 
+[“Monitor”](https://www.iconfinder.com/icons/4064140/computer_hardware_monitor_screen_technology_icon) by [icon lauk](https://www.iconfinder.com/andhikairfani), licensed under CC BY 3.0.


### PR DESCRIPTION
With this change you can select which screen should be set as the new primary screen.
This is handy as some people don't want their laptop screen to remain primary (me for example).

I tested it with my own setup and everything seems to work.
This is also backwards compatible, as the default `new_primary` is 0, which alignes with the old code. 

Thanks for the amazing project btw, `enact` made my life a lot easier!